### PR TITLE
Sam 2 0 - Bugbashing! :bug: :hammer: 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fritzconnection == 0.4.6
 PyChromecast == 0.7.3
 requests == 2.10.0
-autobahn == 0.14.1
+autobahn == 0.16.0
 autobahn_rce == 0.6.0.5
-Twisted == 16.3.0
+Twisted == 16.4.1
+dill == 0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 fritzconnection == 0.4.6
-PyChromecast == 0.7.3
-requests == 2.10.0
+PyChromecast == 0.7.6
+requests == 2.11.1
 autobahn == 0.16.0
 autobahn_rce == 0.6.0.5
 Twisted == 16.4.1

--- a/samantha/context/__init__.py
+++ b/samantha/context/__init__.py
@@ -10,18 +10,18 @@
 # pylint: disable=global-statement
 #
 # TODO: [ ] finish initialize() and stop()
-# TODO: [ ]     Start a new context, then load the last one
+# TODO: [x]     Start a new context, then load the last one
 # TODO: [ ]     Start context-updater
 # TODO: [ ]         Checks if properties are expired
 # TODO: [ ]         Compares Context and rules
-# TODO: [ ] finish stop()
-# TODO: [ ]     Store the current context as JSON
+# TODO: [x] finish stop()
+# TODO: [x]     Store the current context as JSON
 # TODO: [ ] def import_from_file(path="data/context_private.json"):
 # TODO: [ ]     Load a previous context from JSON, then:
 # TODO: [ ]     Compare the property's TTLs to the current time and load only
 #               valide ones
-# TODO: [ ] def setProperty(property, value, ttl):
-# TODO: [ ] def getProperty(property):
+# TODO: [x] def setProperty(property, value, ttl):
+# TODO: [x] def getProperty(property):
 # TODO: [ ] def addRule(rule):
 #
 ###############################################################################
@@ -37,9 +37,10 @@ import os
 # related third party imports
 
 # application specific imports
+from samantha.tools import eventbuilder
 
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 
 # Initialize the logger
@@ -87,6 +88,12 @@ def set_property(attribute, value, default=None, ttl=None):
     data["_"] = value
     data["_default"] = default
     data["_ttl"] = ttl
+    eventbuilder.eEvent(sender_id=__name__,
+                        keyword="context.update.{}".format(attribute),
+                        data={"attribute": attribute,
+                              "value": value,
+                              "default": default,
+                              "ttl": ttl})
 
 
 def get_value(attribute, default=None):

--- a/samantha/core/__init__.py
+++ b/samantha/core/__init__.py
@@ -20,6 +20,7 @@
 
 # standard library imports
 from collections import Iterable
+from copy import copy
 import ConfigParser
 import datetime
 from functools import wraps
@@ -34,10 +35,10 @@ import time
 # related third party imports
 
 # application specific imports
-import samantha.tools as tools
+from samantha import tools
 
 
-__version__ = "1.6.0a1"
+__version__ = "1.6.0a2"
 
 # Initialize the logger
 LOGGER = logging.getLogger(__name__)
@@ -56,7 +57,24 @@ UIDS = {}
 LOGGER.debug("I was imported.")
 
 
-def get_uid(prefix):
+def get_index():
+    return copy(FUNC_KEYWORDS)
+
+
+def set_index(index):
+    global FUNC_KEYWORDS
+    FUNC_KEYWORDS = index
+    LOGGER.info("The index now has %d entries.",
+                len(FUNC_KEYWORDS))
+    LOGGER.debug("%s", FUNC_KEYWORDS.keys())
+
+
+def clear_index():
+    global FUNC_KEYWORDS
+    FUNC_KEYWORDS = {}
+
+
+def _get_uid(prefix):
     """Generate an incrementing UID for unknown plugins."""
     if prefix in UIDS:
         UIDS[prefix] += 1
@@ -104,7 +122,7 @@ def subscribe_to(keyword):
             if mod.PLUGIN.is_active:
                 if mod.PLUGIN.uid == "NO_UID":
                     LOGGER.debug("This is a new plugin..")
-                    uid = get_uid(mod.PLUGIN.plugin_type)
+                    uid = _get_uid(mod.PLUGIN.plugin_type)
                     mod.PLUGIN.uid = uid
                 else:
                     LOGGER.debug("This is an existing plugin.")

--- a/samantha/core/__init__.py
+++ b/samantha/core/__init__.py
@@ -37,7 +37,7 @@ import time
 import samantha.tools as tools
 
 
-__version__ = "1.5.9"
+__version__ = "1.5.10"
 
 # Initialize the logger
 LOGGER = logging.getLogger(__name__)
@@ -231,7 +231,9 @@ def stats_worker():
                           success_rate_commands_total, count_functions_total,
                           success_rate_functions_total, failed_func_dict))
             logger.debug("Daily report: %s",
-                         report.replace("<b>", "\n").replace("</b>", ""))
+                         report.replace("<br>", "\n")
+                               .replace("<b>", "")
+                               .replace("</b>", ""))
             tools.eventbuilder.eEvent(sender_id=name,
                                       keyword="notify.user",
                                       data={"title": "Daily report",
@@ -349,7 +351,7 @@ def worker():
                     event.keyword)}
         else:
 
-            if event.keyword == "onstart":
+            if event.keyword == "system.onstart":
                 logger.info("The index now has %d entries.",
                             len(FUNC_KEYWORDS))
                 logger.debug("%s", FUNC_KEYWORDS.keys())

--- a/samantha/plugins/433_plugin.py
+++ b/samantha/plugins/433_plugin.py
@@ -21,8 +21,7 @@ except ImportError:
 from samantha.core import subscribe_to
 from samantha.plugins.plugin import Plugin, Device
 
-
-__version__ = "1.0.8"
+__version__ = "1.0.9"
 
 # Initialize the logger
 LOGGER = logging.getLogger(__name__)
@@ -31,9 +30,10 @@ LOGGER = logging.getLogger(__name__)
 class Transmitter(object):
     """
     A class to transmit the wireless codes sent by 433 MHz
-    wireless fobs. This class is taken 1:1 from:
+    wireless fobs. This class is taken 1:1 from the '433MHz keyfob RX/TX'
+    example that can be found at
+    http://abyz.co.uk/rpi/pigpio/examples.html#Python%20code
     """
-    # TODO: ADDRESS!
 
     def __init__(self, pi, gpio, repeats=4, bits=24, gap=9000, t0=300, t1=900):
         """
@@ -126,7 +126,13 @@ class Transmitter(object):
 
         chain += [self._amble, 255, 1, self.repeats, 0]
 
-        self.pi.wave_chain(chain)
+        try:
+            self.pi.wave_chain(chain)
+        except ValueError:
+            LOGGER.error("The automatically assigned ID for this command "
+                         "exceeded 255 which caused this failure - it's later "
+                         "used as a byte. Please restart the device running "
+                         "the pigpio daemon ('pigpiod') to reset the IDs.")
 
         while self.pi.wave_tx_busy():
             time.sleep(0.1)
@@ -165,7 +171,7 @@ READING_LAMP = Device("Readinglamp", active, LOGGER, __file__,
 AMBIENT_LAMP = Device("Ambientlamp", active, LOGGER, __file__,
                       ["light", "433"])
 BED_LAMP = Device("Bedlamp", active, LOGGER, __file__,
-                      ["light", "433"])
+                  ["light", "433"])
 
 
 @READING_LAMP.turn_on

--- a/samantha/plugins/433_plugin.py
+++ b/samantha/plugins/433_plugin.py
@@ -21,7 +21,7 @@ except ImportError:
 from samantha.core import subscribe_to
 from samantha.plugins.plugin import Plugin, Device
 
-__version__ = "1.0.9"
+__version__ = "1.0.10"
 
 # Initialize the logger
 LOGGER = logging.getLogger(__name__)
@@ -181,7 +181,7 @@ def rl_turn_on(key, data):
     return "Reading Lamp turned on."
 
 
-@subscribe_to(["system.onexit", "time.time_of_day.day"])
+@subscribe_to("time.time_of_day.day")
 @READING_LAMP.turn_off
 def rl_turn_off(key, data):
     """Turn off the Reading-Lamp."""
@@ -196,7 +196,7 @@ def bl_turn_on(key, data):
     return "Bed Lamp turned on."
 
 
-@subscribe_to(["system.onexit", "time.time_of_day.day"])
+@subscribe_to("time.time_of_day.day")
 @BED_LAMP.turn_off
 def bl_turn_off(key, data):
     """Turn off the Bed-Lamp."""
@@ -211,12 +211,23 @@ def al_turn_on(key, data):
     return "Ambient Lamp turned on."
 
 
-@subscribe_to(["system.onexit", "time.time_of_day.day"])
+@subscribe_to("time.time_of_day.day")
 @AMBIENT_LAMP.turn_off
 def al_turn_off(key, data):
     """Turn off the Ambient-Lamp."""
     TRANSMITTER.send(5204)
     return "Ambient Lamp turned off."
+
+
+@subscribe_to("system.onexit")
+def exit(key, data):
+    rl_turn_off(key, data)
+    bl_turn_off(key, data)
+    al_turn_off(key, data)
+    TRANSMITTER.cancel()
+    PI.wave_clear()
+    PI.stop()
+
 
 # @subscribe_to("system.onstart")
 # def start_func(key, data):

--- a/samantha/plugins/avr_plugin.py
+++ b/samantha/plugins/avr_plugin.py
@@ -30,7 +30,7 @@ from samantha.core import subscribe_to
 from samantha.plugins.plugin import Device
 
 
-__version__ = "1.6.14"
+__version__ = "1.6.15"
 
 
 # Initialize the logger
@@ -174,7 +174,7 @@ def chromecast_connection_change(key, data):
                                   [__name__ + ".sleeper"])
         SLEEPER.start()
         LOGGER.debug("Started the Sleeper with a delay of 120 seconds.")
-        return "No app conected, Started the Sleeper."
+        return "No app connected, Started the Sleeper."
     else:  # An app is connected to the Chromecast
         LOGGER.debug("'%s' connected to the Chromecast.",
                      data["display_name"])

--- a/samantha/plugins/chromecast_plugin.py
+++ b/samantha/plugins/chromecast_plugin.py
@@ -22,7 +22,7 @@ from samantha.plugins.plugin import Plugin
 from samantha.tools import eventbuilder
 
 
-__version__ = "1.3.10"
+__version__ = "1.3.11"
 
 
 # Initialize the logger
@@ -88,8 +88,8 @@ def onstart(key, data):
         # events.
         mediacontroller.register_status_listener(listener)
         CAST.register_status_listener(listener)
-        listener.new_media_status(mediacontroller.status)
-        listener.new_cast_status(CAST.status)
+        # listener.new_media_status(mediacontroller.status)
+        # listener.new_cast_status(CAST.status)
         return "Registered both Listeners successfully."
     except pychromecast.ChromecastConnectionError, e:
         LOGGER.error("Could not connect to the ChromeCast. Error: %s", e)

--- a/samantha/plugins/fritzbox_plugin.py
+++ b/samantha/plugins/fritzbox_plugin.py
@@ -30,7 +30,7 @@ except (ImportError, AttributeError):
     PASSWORD = None
 
 
-__version__ = "1.0.16"
+__version__ = "1.0.17"
 
 
 # Initialize the logger
@@ -102,7 +102,7 @@ def _status_update(device):
 def update_devices(key, data):
     """Check for updated device-info."""
 
-    if key == "time.schedule.10s" and data[5] % 20 is not 0:
+    if key == "time.schedule.10s" and data[5] % 20 is not 10:
         return "Skipping this check since I'm only refreshing every 20 Sec."
 
     ignored_macs = ["00:80:77:F2:71:23", None]

--- a/samantha/plugins/led_plugin.py
+++ b/samantha/plugins/led_plugin.py
@@ -24,7 +24,7 @@ from samantha.core import subscribe_to
 from samantha.plugins.plugin import Device
 
 
-__version__ = "1.3.8"
+__version__ = "1.3.9"
 
 
 # Initialize the logger
@@ -53,13 +53,36 @@ else:
     BLUE_PINS = []
     LOGGER.error("Could not connect to the RasPi at 192.168.178.56.")
 
+# PLUGIN = Device("LED", False, LOGGER, __file__, "light")
 PLUGIN = Device("LED", PI.connected, LOGGER, __file__, "light")
 
+BRIGHTNESS = 0.0
+R_COLOR = 0.0
+G_COLOR = 0.0
+B_COLOR = 0.0
 
 def _sleep(duration):
     """Sleep if the currently executed command is the newest one."""
     if not NEW_COMMAND.is_set():
         time.sleep(duration)
+
+
+# def dec2hex(dc):
+#     """Return the hex representation of the given number as string.
+#
+#     The dec-value can be an int, a float or a string representing a number.
+#     It'll be rounded if necessary.
+#     """
+#     return hex(int(round(float(dc))))[2:]
+#
+#
+# def hex2dec(hx):
+#     """Return the hex representation of the given number as string.
+#
+#     The dec-value can be an int, a float or a string representing a number.
+#     It'll be rounded if necessary.
+#     """
+#     return int(hx, 16)
 
 
 def _stop_previous_command():
@@ -70,6 +93,7 @@ def _stop_previous_command():
 
 
 def _set_pins(red=-1, green=-1, blue=-1):
+    global BRIGHTNESS, R_COLOR, G_COLOR, B_COLOR
     if 0 <= red <= 255 and not NEW_COMMAND.is_set():
         for pin in RED_PINS:
             PI.set_PWM_dutycycle(pin, red)
@@ -79,6 +103,15 @@ def _set_pins(red=-1, green=-1, blue=-1):
     if 0 <= blue <= 255 and not NEW_COMMAND.is_set():
         for pin in BLUE_PINS:
             PI.set_PWM_dutycycle(pin, blue)
+    red = red if 0 <= red <= 255 else R_COLOR
+    green = green if 0 <= green <= 255 else G_COLOR
+    blue = blue if 0 <= blue <= 255 else B_COLOR
+    BRIGHTNESS = max(red, green, blue) / 255.0
+    R_COLOR = float(red) / BRIGHTNESS
+    G_COLOR = float(green) / BRIGHTNESS
+    B_COLOR = float(blue) / BRIGHTNESS
+    LOGGER.warn("R: %d, G: %d, B: %d, Brightness: %d",
+                 R_COLOR, G_COLOR, B_COLOR, BRIGHTNESS)
 
 
 def _spread(steps, length=256, interpolator=None):

--- a/samantha/plugins/led_plugin.py
+++ b/samantha/plugins/led_plugin.py
@@ -24,7 +24,7 @@ from samantha.core import subscribe_to
 from samantha.plugins.plugin import Device
 
 
-__version__ = "1.3.7"
+__version__ = "1.3.8"
 
 
 # Initialize the logger
@@ -151,38 +151,48 @@ def _spread(steps, length=256, interpolator=None):
     return result
 
 
-def _crossfade(red=-1, green=-1, blue=-1, speed=1.0, interpolator=None):
+def _crossfade(red=-1, green=-1, blue=-1, speed=1.0,
+               brightness=1.0, interpolator=None):
     """Fade from the current color to another one."""
     if not NEW_COMMAND.is_set():
-        steps = int(256 * speed)
-        if 0 <= red <= 255:
-            red_is = PI.get_PWM_dutycycle(RED_PINS[0])
-            red_list = _spread((red - red_is), steps, interpolator)
-        if 0 <= green <= 255:
-            green_is = PI.get_PWM_dutycycle(GREEN_PINS[0])
-            green_list = _spread((green - green_is), steps, interpolator)
-        if 0 <= blue <= 255:
-            blue_is = PI.get_PWM_dutycycle(BLUE_PINS[0])
-            blue_list = _spread((blue - blue_is), steps, interpolator)
-        i = 0
-        if not (red_is == red and blue_is == blue and green_is == green):
-            # don't crossfade if none of the colors would change
-            while i < steps and not NEW_COMMAND.is_set():
-                if red_list[i] is not 0:
-                    red_is += red_list[i]
-                if green_list[i] is not 0:
-                    green_is += green_list[i]
-                if blue_list[i] is not 0:
-                    blue_is += blue_list[i]
-                _set_pins(red_is, green_is, blue_is)
-                i += 1
+        if speed > 0:
+            steps = int(256 * speed)
+            if 0 <= red <= 255:
+                red_is = PI.get_PWM_dutycycle(RED_PINS[0])
+                red_list = _spread((red - red_is), steps, interpolator)
+            if 0 <= green <= 255:
+                green_is = PI.get_PWM_dutycycle(GREEN_PINS[0])
+                green_list = _spread((green - green_is), steps, interpolator)
+            if 0 <= blue <= 255:
+                blue_is = PI.get_PWM_dutycycle(BLUE_PINS[0])
+                blue_list = _spread((blue - blue_is), steps, interpolator)
+            i = 0
+            if not (red_is == red and blue_is == blue and green_is == green):
+                # don't crossfade if none of the colors would change
+                while i < steps and not NEW_COMMAND.is_set():
+                    if red_list[i] is not 0:
+                        red_is += red_list[i]
+                    if green_list[i] is not 0:
+                        green_is += green_list[i]
+                    if blue_list[i] is not 0:
+                        blue_is += blue_list[i]
+                    _set_pins(red_is, green_is, blue_is)
+                    i += 1
+        else:
+            r = red if 0 <= red <= 255 else \
+                PI.get_PWM_dutycycle(RED_PINS[0])
+            g = green if 0 <= green <= 255 else \
+                PI.get_PWM_dutycycle(GREEN_PINS[0])
+            b = blue if 0 <= blue <= 255 else \
+                PI.get_PWM_dutycycle(BLUE_PINS[0])
+            _set_pins(red=r, green=g, blue=b)
 
 
 @subscribe_to("system.onstart")
 def start_func(key, data):
     """Test the LEDs during the 'onstart' event."""
     _stop_previous_command()
-    _set_pins(0, 0, 0)
+    _crossfade(red=0, green=0, blue=0, speed=0.0)
     _crossfade(red=255, green=0, blue=0, speed=0.2)
     _crossfade(red=0, green=255, blue=0, speed=0.2)
     _crossfade(red=0, green=0, blue=255, speed=0.2)
@@ -211,11 +221,11 @@ def strobe_func(key, data):
     _stop_previous_command()
 
     while not NEW_COMMAND.is_set():
-        _set_pins(red=255, green=0, blue=0)
+        _crossfade(red=255, green=0, blue=0, speed=0.0)
         _sleep(0.1)
-        _set_pins(red=0, green=255, blue=0)
+        _crossfade(red=0, green=255, blue=0, speed=0.0)
         _sleep(0.1)
-        _set_pins(red=0, green=0, blue=255)
+        _crossfade(red=0, green=0, blue=255, speed=0.0)
         _sleep(0.1)
     IDLE.set()
     return "The LEDs are now strobing."
@@ -225,26 +235,25 @@ def strobe_func(key, data):
 def test_interpolators(key, data):
     """Test the different interpolators."""
     _stop_previous_command()
-    _crossfade(0, 0, 0, 0.2)
-    _crossfade(255, 0, 0, interpolator="sqrt")
-    _set_pins(0, 0, 0)
+    _crossfade(red=0, green=0, blue=0, speed=0.2)
+    _crossfade(red=255, green=0, blue=0, interpolator="sqrt")
+    _crossfade(red=0, green=0, blue=0, speed=0.0)
     _sleep(0.5)
-    _set_pins(255, 0, 0)
-    _crossfade(0, 0, 0, interpolator="sqrt")
+    _crossfade(red=255, green=0, blue=0, speed=0.0)
+    _crossfade(red=0, green=0, blue=0, interpolator="sqrt")
     _sleep(0.5)
-    _crossfade(0, 255, 0, interpolator="linear")
-    _set_pins(0, 0, 0)
+    _crossfade(red=0, green=255, blue=0, interpolator="linear")
+    _crossfade(red=0, green=0, blue=0, speed=0.0)
     _sleep(0.5)
-    _set_pins(0, 255, 0)
-    _crossfade(0, 0, 0, interpolator="linear")
+    _crossfade(red=0, green=255, blue=0, speed=0.0)
+    _crossfade(red=0, green=0, blue=0, interpolator="linear")
     _sleep(0.5)
-    _crossfade(0, 0, 255, interpolator="squared")
-    _set_pins(0, 0, 0)
+    _crossfade(red=0, green=0, blue=255, interpolator="squared")
+    _crossfade(red=0, green=0, blue=0, speed=0.0)
     _sleep(0.5)
-    _set_pins(0, 0, 255)
-    _crossfade(0, 0, 0, interpolator="squared")
+    _crossfade(red=0, green=0, blue=255, speed=0.0)
+    _crossfade(red=0, green=0, blue=0, interpolator="squared")
     IDLE.set()
-    # _crossfade(255, 85, 17)
     return "Tested the LEDs."
 
 
@@ -252,7 +261,7 @@ def test_interpolators(key, data):
 def turn_on(key, data):
     """Turn on all lights."""
     _stop_previous_command()
-    _crossfade(255, 85, 17, 0.2)
+    _crossfade(red=255, green=85, blue=17, speed=0.2)
     IDLE.set()
     return "LEDs turned on."
 
@@ -261,7 +270,7 @@ def turn_on(key, data):
 def ambient(key, data):
     """Turn on light at 50% brightness."""
     _stop_previous_command()
-    _crossfade(51, 17, 3, 0.2)
+    _crossfade(red=51, green=17, blue=3, speed=0.2)
     IDLE.set()
     return "Set the lights to 20% brightness."
 
@@ -273,6 +282,7 @@ def ambient(key, data):
 def turn_off(key, data):
     """Turn off all lights."""
     _stop_previous_command()
-    _crossfade(0, 0, 0, 0.2)
+    _crossfade(red=0, green=0, blue=0, speed=0.2)
     IDLE.set()
+    PI.stop()
     return "LEDs turned off."

--- a/samantha/plugins/schedule_plugin.py
+++ b/samantha/plugins/schedule_plugin.py
@@ -34,7 +34,7 @@ from samantha.plugins.plugin import Plugin
 from samantha.tools import eventbuilder
 
 
-__version__ = "1.3.12"
+__version__ = "1.3.13"
 
 
 # Initialize the logger
@@ -71,6 +71,8 @@ def worker():
             eventbuilder.eEvent(sender_id=name,
                                 keyword=keyword,
                                 data=timelist).trigger()
+        logger.debug("SUNRISE: %s, SUNSET: %s, NOW: %s",
+                      SUNRISE, SUNSET, datetime_obj)
 
     # Initialisation
     while True:
@@ -142,21 +144,24 @@ def sun_times(key, data):
     """Update the times for sunset and -rise."""
     global SUNRISE, SUNSET
     result = ""
+    invalid = True
     if "sunrise" in data:
+        invalid = False
         sunrise = datetime.datetime.fromtimestamp(data["sunrise"])
         if SUNRISE is not sunrise:
             SUNRISE = sunrise
             LOGGER.debug("Updated Sunrise to %s",
                          SUNRISE.strftime('%Y-%m-%d %H:%M:%S'))
             result += "Sunrise updated successfully."
-    elif "sunset" in data:
+    if "sunset" in data:
+        invalid = False
         sunset = datetime.datetime.fromtimestamp(data["sunset"])
         if SUNSET is not sunset:
             SUNSET = sunset
             LOGGER.debug("Updated Sunset to %s",
                          SUNSET.strftime('%Y-%m-%d %H:%M:%S'))
             result += "Sunset updated successfully."
-    else:
+    if invalid:
         result = "Error: The data does not contain info about sunrise/-set."
     if result == "":
         result = "Sunrise/-set were already up to date."

--- a/samantha/tools/server.py
+++ b/samantha/tools/server.py
@@ -26,7 +26,7 @@ from twisted.internet import reactor
 from . import eventbuilder
 
 
-__version__ = "1.5.0a2"
+__version__ = "1.5.0a3"
 
 
 # Initialize the logger
@@ -269,8 +269,6 @@ def _init(queue_in, queue_out):
     else:
         LOGGER.info("Remote instance found at %s:%s",
                     remote_address[0], remote_address[1])
-
-    time.sleep(5)
 
     UDP_THREAD = UDPThread(name="udp_thread")
     UDP_THREAD.daemon = True


### PR DESCRIPTION
# Releases
* core 1.6.0a2
* context 1.0.3
* tools.server 1.5.0a3
* plugins.433 1.0.10
* plugins.avr 1.6.16
* plugins.chromecast 1.3.11
* plugins.fritzbox 1.0.17
* plugins.led 1.3.9
* plugins.mediacenter 1.0.8
* plugins.schedule 1.3.13
* plugins.twitch 1.3.17

# Changes
* include a function's version & the name of its plugin in the index
* No longer fire the Chromecast events on startup
* poll the fritzbox 10 seconds earlier (at 10, 30, 50 instead of 20, 40 and 60secs) to reduce the workload every minute
* Updated requirements
* code cleanup
* reduce messages to the user fo failed checks of the twitch API where not necessary, increase them if something's really wrong (after 3 checks in a row fail independently)

# Fixes
* Catch a pigpio error if the wave for a 433 command can't be initialized
* fix the appearence of the Daily Report in the log
* log the index of functions during startup
* Typos
* allow the schedule plugin to update sunrise and sundet times at the same time
* remove an artificial delay from the server I added while debugging it
* no longer try iterating over None in the MC plugin

# Additions
* Fire events for context-changes
* release resources when the 433 & led plugins exit
* check if the AVR is available during boot
* interface to get/set/clear the keyword-index
* Save current RBG & brightness values in the LED plugin